### PR TITLE
Fixed a bug when calling context_code without linecount (default to 8)

### DIFF
--- a/peda.py
+++ b/peda.py
@@ -4190,6 +4190,9 @@ class PEDACmd(object):
         """
         (count,) = normalize_argv(arg, 1)
 
+        if count is None:
+            count = 8
+
         if not self._is_running():
             return
 


### PR DESCRIPTION
In context_code, normalize_args() set count to None if you don't set the linecount parameter, which makes peda crash.

I set the default value of count to 8 so it works even without specifying the linecount parameter (which should be optional).
