### PR TITLE
allow arguments for start command

### DIFF
--- a/peda.py
+++ b/peda.py
@@ -3853,7 +3853,7 @@ class PEDACmd(object):
         for e in entries:
             out = peda.execute_redirect("tbreak %s" % e)
             if out and "breakpoint" in out:
-                peda.execute("run")
+                peda.execute("run %s" % ' '.join(arg))
                 started = 1
                 break
 


### PR DESCRIPTION
Recent versions of GDB feature a `start` command that does the same thing as the Peda `start` command.  However, it allows arguments in the same fashion as the `run` command.

This patch adds that functionality.  Example:

```
$ gdb ls
...
gdb-peda$ start /proc/self/fd -la
...
Temporary breakpoint 2, 0x00000000004028c0 in ?? ()
gdb-peda$ context stack 3
[------------------------------------stack-------------------------------------]
0000| 0x7fffffffd668 --> 0x7ffff760aec5 (<__libc_start_main+245>:       mov    edi,eax)
0008| 0x7fffffffd670 --> 0x0 
0016| 0x7fffffffd678 --> 0x7fffffffd748 --> 0x7fffffffdb37 --> 0x736c2f6e69622f ('/bin/ls')
[------------------------------------------------------------------------------]
Legend: code, data, rodata, value
gdb-peda$ c
Continuing.
total 0
dr-x------ 2 user user  0 Jul  3 18:07 .
dr-xr-xr-x 9 user user  0 Jul  3 18:07 ..
lrwx------ 1 user user 64 Jul  3 18:07 0 -> /dev/pts/3
lrwx------ 1 user user 64 Jul  3 18:07 1 -> /dev/pts/3
lrwx------ 1 user user 64 Jul  3 18:07 2 -> /dev/pts/3
lr-x------ 1 user user 64 Jul  3 18:07 3 -> /proc/13687/fd
[Inferior 1 (process 13687) exited normally]
```
