### PR TITLE
Procfs warning message for FreeBSD

### DIFF
--- a/peda.py
+++ b/peda.py
@@ -1427,7 +1427,8 @@ class PEDA(object):
             if remote: # remote target, not yet supported
                 return maps
             else: # local target
-                out = open(mpath).read()
+                try:  out = open(mpath).read()
+                except: error_msg("could not open %s; is procfs mounted?" % mpath)
 
             matches = pattern.findall(out)
             if matches:


### PR DESCRIPTION
On FreeBSD, procfs is not enabled/mounted by default.  When running Peda on FreeBSD, it will silently fail when trying to open `/proc/self/maps`.

Print an error message when this occurs, rather than failing silently.
