### PR TITLE
Fixed the wrong checksec output 'RELRO: Full' when there is BIND_NOW but not GNU_RELRO

### DIFF
--- a/peda.py
+++ b/peda.py
@@ -2528,9 +2528,12 @@ class PEDA(object):
 
         for line in out.splitlines():
             if "GNU_RELRO" in line:
-                result["RELRO"] = 2 # Partial
+                result["RELRO"] = 2 # Partial | NO BIND_NOW + GNU_RELRO
             if "BIND_NOW" in line:
-                result["RELRO"] = 3 # Full
+	    	if result["RELRO"] == 2:
+                 result["RELRO"] = 3 # Full | BIND_NOW + GNU_RELRO 
+                else:
+                 result["RELRO"] = 0 # ? | BIND_NOW + NO GNU_RELRO = NO PROTECTION
             if "__stack_chk_fail" in line:
                 result["CANARY"] = 1
             if "GNU_STACK" in line and "RWE" in line:


### PR DESCRIPTION
This is a very small fix. While I was doing some challenges peda's checksec command said me that there was FULL RELRO, but actually that wasn't true. 
This happen  because peda checks only the BIND_NOW flag from the readelf -dW command in order to mark the binaries as protected by FULL RELRO.
Sometimes, strangely, can happen that there is the BIND_NOW flag but not the GNU_RELRO one, in these case the GOT isn't full protected and we can overwrite the pointer inside it because it isn't RO.
I think that with this small fix the report of the checksec command is clearer than before.

I leave here a small table of comparison made between different binaries in order to understand better the small problem that I think peda had.
![comparison](https://cloud.githubusercontent.com/assets/4940271/8943773/bfb4e616-357c-11e5-9b73-77ba3cacbdcf.jpg)
