### PR TITLE
add owasp zsc api

### DIFF
--- a/lib/shellcode.py
+++ b/lib/shellcode.py
@@ -14,7 +14,8 @@ import random
 import socket
 import struct
 import traceback
-
+import httplib
+import urllib
 import six.moves.http_client
 from six.moves import range
 
@@ -358,3 +359,22 @@ class Shellcode():
         data = data.replace("&lt;", "<")
         data = data.replace("&gt;", ">")
         return data
+    #OWASP ZSC API Z3r0D4y.Com
+    def zsc(self,os,job,encode):
+        try:
+	    msg('Connection to OWASP ZSC API api.z3r0d4y.com')
+            params = urllib.urlencode({
+                      'api_name': 'zsc', 
+                      'os': os,
+                      'job': job,
+                      'encode': encode})
+            headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:41.0) Gecko/20100101 Firefox/41.0 [GDB-PEDA]'}
+            conn = httplib.HTTPConnection('api.z3r0d4y.com')
+            conn.request("POST", "", params, headers)
+            return '\n"'+conn.getresponse().read().replace('\n','')+'"\n'
+        except:
+            error_msg("Error while connecting to api.z3r0d4y.com ...")
+            return None
+
+
+

--- a/lib/shellcode.py
+++ b/lib/shellcode.py
@@ -14,14 +14,21 @@ import random
 import socket
 import struct
 import traceback
-import httplib
-import urllib
 import six.moves.http_client
 from six.moves import range
+import sys
 
 import config
 from utils import msg, error_msg
 
+if sys.version_info.major is 3:
+    from urllib.request import urlopen
+    from urllib.parse import urlencode
+    pyversion = 3
+else:
+    from urllib import urlopen
+    from urllib import urlencode
+    pyversion = 2
 
 def _make_values_bytes(dict_):
     """Make shellcode in dictionaries bytes"""
@@ -362,19 +369,16 @@ class Shellcode():
     #OWASP ZSC API Z3r0D4y.Com
     def zsc(self,os,job,encode):
         try:
-	    msg('Connection to OWASP ZSC API api.z3r0d4y.com')
-            params = urllib.urlencode({
-                      'api_name': 'zsc', 
-                      'os': os,
-                      'job': job,
-                      'encode': encode})
-            headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:41.0) Gecko/20100101 Firefox/41.0 [GDB-PEDA]'}
-            conn = httplib.HTTPConnection('api.z3r0d4y.com')
-            conn.request("POST", "", params, headers)
-            return '\n"'+conn.getresponse().read().replace('\n','')+'"\n'
+            msg('Connection to OWASP ZSC API api.z3r0d4y.com')
+            params = urlencode({
+                    'api_name': 'zsc', 
+                    'os': os,
+                    'job': job,
+                    'encode': encode})
+            shellcode = urlopen("http://api.z3r0d4y.com/index.py?%s\n"%(str(params))).read()
+            if pyversion is 3:
+                shellcode = str(shellcode,encoding='ascii')
+            return '\n"'+shellcode.replace('\n','')+'"\n'
         except:
             error_msg("Error while connecting to api.z3r0d4y.com ...")
             return None
-
-
-

--- a/peda.py
+++ b/peda.py
@@ -43,7 +43,15 @@ from utils import *
 import config
 from nasm import *
 
-
+if sys.version_info.major is 3:
+    from urllib.request import urlopen
+    from urllib.parse import urlencode
+    pyversion = 3
+else:
+    from urllib import urlopen
+    from urllib import urlencode
+    pyversion = 2
+	
 REGISTERS = {
     8 : ["al", "ah", "bl", "bh", "cl", "ch", "dl", "dh"],
     16: ["ax", "bx", "cx", "dx"],
@@ -5728,50 +5736,59 @@ class PEDACmd(object):
 
             msg(res)
 	#OWASP ZSC API Z3r0D4y.Com
-	elif mode == "zsc":
-		'os lists'
-		oslist = ['linux_x86','linux_x64','linux_arm','linux_mips','freebsd_x86',
-			'freebsd_x64','windows_x86','windows_x64','osx','solaris_x64','solaris_x86']
-		'functions'
-		joblist = ['exec(\'/path/file\')','chmod(\'/path/file\',\'permission number\')','write(\'/path/file\',\'text to write\')',
-			'file_create(\'/path/file\',\'text to write\')','dir_create(\'/path/folder\')','download(\'url\',\'filename\')',
-			'download_execute(\'url\',\'filename\',\'command to execute\')','system(\'command to execute\')']
-		'encode types'
-		encodelist = ['none','xor_random','xor_yourvalue','add_random','add_yourvalue','sub_random',
-			'sub_yourvalue','inc','inc_timeyouwant','dec','dec_timeyouwant','mix_all']
-		try:
-			while True:
-				for os in oslist:
-					msg('%s %s'%(yellow('[+]'),green(os)))
-				os = raw_input('%s'%blue('os:'))
-				if os in oslist: #check if os exist 
-					break
-				else:
-					warning_msg("Wrong input! Try Again.")
-			while True:
-				for job in joblist:
-					msg('%s %s'%(yellow('[+]'),green(job)))
-				job = raw_input('%s'%blue('job:'))
-				if job != '':
-					break
-				else:
-					warning_msg("Please enter a function.")
-			while True:
-				for encode in encodelist:
-					msg('%s %s'%(yellow('[+]'),green(encode)))
-				encode = raw_input('%s'%blue('encode:'))
-				if encode != '':
-					break
-				else:
-					warning_msg("Please enter a encode type.")
-		except (KeyboardInterrupt, SystemExit):
-			warning_msg("Aborted by user")
-		result = Shellcode().zsc(os,job,encode)
-		if result is not None:
-			msg(result)
-		else:
-			pass
-		return
+        elif mode == "zsc":
+            'os lists'
+            oslist = ['linux_x86','linux_x64','linux_arm','linux_mips','freebsd_x86',
+                    'freebsd_x64','windows_x86','windows_x64','osx','solaris_x64','solaris_x86']
+            'functions'
+            joblist = ['exec(\'/path/file\')','chmod(\'/path/file\',\'permission number\')','write(\'/path/file\',\'text to write\')',
+                    'file_create(\'/path/file\',\'text to write\')','dir_create(\'/path/folder\')','download(\'url\',\'filename\')',
+                    'download_execute(\'url\',\'filename\',\'command to execute\')','system(\'command to execute\')']
+            'encode types'
+            encodelist = ['none','xor_random','xor_yourvalue','add_random','add_yourvalue','sub_random',
+                    'sub_yourvalue','inc','inc_timeyouwant','dec','dec_timeyouwant','mix_all']
+            try:
+                while True:
+                    for os in oslist:
+                        msg('%s %s'%(yellow('[+]'),green(os)))
+                    if pyversion is 2:
+                        os = input('%s'%blue('os:'))
+                    if pyversion is 3:
+                        os = input('%s'%blue('os:'))
+                    if os in oslist: #check if os exist 
+                        break
+                    else:
+                        warning_msg("Wrong input! Try Again.")
+                while True:
+                    for job in joblist:
+                        msg('%s %s'%(yellow('[+]'),green(job)))
+                    if pyversion is 2:
+                        job = raw_input('%s'%blue('job:'))
+                    if pyversion is 3:
+                        job = input('%s'%blue('job:'))
+                    if job != '':
+                        break
+                    else:
+                        warning_msg("Please enter a function.")
+                while True:
+                    for encode in encodelist:
+                        msg('%s %s'%(yellow('[+]'),green(encode)))
+                    if pyversion is 2:
+                        encode = raw_input('%s'%blue('encode:'))
+                    if pyversion is 3:
+                        encode = input('%s'%blue('encode:'))
+                    if encode != '':
+                        break
+                    else:
+                        warning_msg("Please enter a encode type.")
+            except (KeyboardInterrupt, SystemExit):
+                warning_msg("Aborted by user")
+            result = Shellcode().zsc(os,job,encode)
+            if result is not None:
+                msg(result)
+            else:
+                pass
+            return
         else:
             self._missing_argument()
 

--- a/peda.py
+++ b/peda.py
@@ -5644,6 +5644,7 @@ class PEDACmd(object):
             MYNAME generate [arch/]platform type [port] [host]
             MYNAME search keyword (use % for any character wildcard)
             MYNAME display shellcodeId (shellcodeId as appears in search results)
+	    MYNAME zsc [generate customize shellcode] 
 
             For generate option:
                 default port for bindport shellcode: 16706 (0x4142)
@@ -5726,12 +5727,56 @@ class PEDACmd(object):
                 return
 
             msg(res)
-
+	#OWASP ZSC API Z3r0D4y.Com
+	elif mode == "zsc":
+		'os lists'
+		oslist = ['linux_x86','linux_x64','linux_arm','linux_mips','freebsd_x86',
+			'freebsd_x64','windows_x86','windows_x64','osx','solaris_x64','solaris_x86']
+		'functions'
+		joblist = ['exec(\'/path/file\')','chmod(\'/path/file\',\'permission number\')','write(\'/path/file\',\'text to write\')',
+			'file_create(\'/path/file\',\'text to write\')','dir_create(\'/path/folder\')','download(\'url\',\'filename\')',
+			'download_execute(\'url\',\'filename\',\'command to execute\')','system(\'command to execute\')']
+		'encode types'
+		encodelist = ['none','xor_random','xor_yourvalue','add_random','add_yourvalue','sub_random',
+			'sub_yourvalue','inc','inc_timeyouwant','dec','dec_timeyouwant','mix_all']
+		try:
+			while True:
+				for os in oslist:
+					msg('%s %s'%(yellow('[+]'),green(os)))
+				os = raw_input('%s'%blue('os:'))
+				if os in oslist: #check if os exist 
+					break
+				else:
+					warning_msg("Wrong input! Try Again.")
+			while True:
+				for job in joblist:
+					msg('%s %s'%(yellow('[+]'),green(job)))
+				job = raw_input('%s'%blue('job:'))
+				if job != '':
+					break
+				else:
+					warning_msg("Please enter a function.")
+			while True:
+				for encode in encodelist:
+					msg('%s %s'%(yellow('[+]'),green(encode)))
+				encode = raw_input('%s'%blue('encode:'))
+				if encode != '':
+					break
+				else:
+					warning_msg("Please enter a encode type.")
+		except (KeyboardInterrupt, SystemExit):
+			warning_msg("Aborted by user")
+		result = Shellcode().zsc(os,job,encode)
+		if result is not None:
+			msg(result)
+		else:
+			pass
+		return
         else:
             self._missing_argument()
 
         return
-    shellcode.options = ["generate", "search", "display"]
+    shellcode.options = ["generate", "search", "display","zsc"]
 
     def gennop(self, *arg):
         """


### PR DESCRIPTION
I add owasp zsc api to generate customize shellcodes, And it's how it working:

```
gdb-peda$ shellcode
Error: missing argument
Generate or download common shellcodes.
Usage:
    shellcode generate [arch/]platform type [port] [host]
    shellcode search keyword (use % for any character wildcard)
    shellcode display shellcodeId (shellcodeId as appears in search results)
    shellcode zsc [generate customize shellcode]

    For generate option:
        default port for bindport shellcode: 16706 (0x4142)
        default host/port for connect back shellcode: 127.127.127.127/16706
        supported arch: x86
gdb-peda$ shellcode zsc
[+] linux_x86
[+] linux_x64
[+] linux_arm
[+] linux_mips
[+] freebsd_x86
[+] freebsd_x64
[+] windows_x86
[+] windows_x64
[+] osx
[+] solaris_x64
[+] solaris_x86
os:linux_x86
[+] exec('/path/file')
[+] chmod('/path/file','permission number')
[+] write('/path/file','text to write')
[+] file_create('/path/file','text to write')
[+] dir_create('/path/folder')
[+] download('url','filename')
[+] download_execute('url','filename','command to execute')
[+] system('command to execute')
job:exec('/bin/bash')
[+] none
[+] xor_random
[+] xor_yourvalue
[+] add_random
[+] add_yourvalue
[+] sub_random
[+] sub_yourvalue
[+] inc
[+] inc_timeyouwant
[+] dec
[+] dec_timeyouwant
[+] mix_all
encode:mix_all
Connection to OWASP ZSC API api.z3r0d4y.com

"\x6a\x41\x58\x83\xf0\x07\x31\xdb\x31\xc9\xcd\x80\x68\x90\x90\x90\x68\x5b\xc1\xeb\x10\xc1\xeb\x08\x53\x68\x2f\x62\x61\x73\x68\x2f\x62\x69\x6e\x89\xe3\x31\xc0\xb0\x0b\xcd\x80\xb0\x01\xb3\x01\xcd\x80"

gdb-peda$ 
```

Thank you.