### PR TITLE
Changed dict comprehension for 2.6.6 support

### DIFF
--- a/lib/shellcode.py
+++ b/lib/shellcode.py
@@ -24,7 +24,7 @@ from utils import msg, error_msg
 
 def _make_values_bytes(dict_):
     """Make shellcode in dictionaries bytes"""
-    return {k: six.b(v) for k, v in dict_.items()}
+    return dict((k, six.b(v)) for k, v in dict_.items())
 
 
 shellcode_x86_linux = _make_values_bytes({


### PR DESCRIPTION
Replaced a dictionary comprehension with a generator and a call to dict to allow peda to load on older builds of gdb.