### PR TITLE
Added a pprint function to display prettily the memory at specified offset

### DIFF
--- a/peda.py
+++ b/peda.py
@@ -4401,6 +4401,26 @@ class PEDACmd(object):
 
         return
 
+    @msg.bufferize
+    def pprint(self, *arg):
+        """
+        Display prettily memory at offset
+        Usage:
+            MYNAME [offset] [linecount]
+        """
+        (offset, count) = normalize_argv(arg, 2)
+
+        if not self._is_running():
+            return
+
+        text = blue("[%s]" % "stack".center(78, "-"))
+        msg(text)
+        if peda.is_address(offset):
+            self.telescope(offset, count)
+        else:
+            msg("Invalid $OFFSET address: 0x%x" % offset, "red")
+
+        return
 
     #################################
     #   Memory Operation Commands   #


### PR DESCRIPTION
I needed to inspect my heap and I found x/x too 'ugly' so I wrote this small function to print the memory at a desired offset using the same format as context_stack