### PR TITLE
Fixed shellcode display for PY3 due to missing decode

### DIFF
--- a/lib/shellcode.py
+++ b/lib/shellcode.py
@@ -356,7 +356,7 @@ class Shellcode():
         try:
             s.request("GET", "/shellcode/files/shellcode-"+str(shellcodeId)+".php")
             res = s.getresponse()
-            data = res.read().split("<pre>")[1].split("<body>")[0]
+            data = res.read().decode('utf-8').split("<pre>")[1].split("<body>")[0]
         except:
             error_msg("Failed to download shellcode from shell-storm.org")
             return None


### PR DESCRIPTION
Tested with Python 2.7.3 and 3.5.1+ under Ubuntu 12.04 and 16.04