### PR TITLE
added the got command to show fastly the state of the GOT table

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -18,6 +18,7 @@ READELF      = "/usr/bin/readelf"
 OBJDUMP      = "/usr/bin/objdump"
 NASM         = "/usr/bin/nasm"
 NDISASM      = "/usr/bin/ndisasm"
+FILE         = "/usr/bin/file"
 
 # PEDA global options
 OPTIONS = {
@@ -25,7 +26,7 @@ OPTIONS = {
     "pattern"   : (1, "pattern type, 0 = basic, 1 = extended, 2 = maximum"),
     "p_charset" : ("", "custom charset for pattern_create"),
     "indent"    : (4, "number of ident spaces for output python payload, e.g: 0|4|8"),
-    "ansicolor" : ("on", "enable/disable colorized output, e.g: on|off"),    
+    "ansicolor" : ("on", "enable/disable colorized output, e.g: on|off"),
     "pagesize"  : (25, "number of lines to display per page, 0 = disable paging"),
     "session"   : ("peda-session-#FILENAME#.txt", "target file to save peda session"),
     "tracedepth": (0, "max depth for calls/instructions tracing, 0 means no limit"),


### PR DESCRIPTION
Added the command "got" used to retrieve fastly the state of the GOT table.
It works for 32 and 64 binaries and also for PIE programs.

Example 64 bit - PIE OFF :
![image](https://cloud.githubusercontent.com/assets/4940271/15804937/5446bbea-2b1a-11e6-99d2-8b24ffd9a890.png)

Example 64 bit - PIE ON:
![image](https://cloud.githubusercontent.com/assets/4940271/15804995/e135577c-2b1b-11e6-8175-4669b11b6384.png)

Example 32 bit:
![image](https://cloud.githubusercontent.com/assets/4940271/15805000/1525898a-2b1c-11e6-8a7e-6b2d2e8cd9c9.png)


 


