### PR TITLE
Use of shell _aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+
+#Linux backups
+*~*

--- a/peda.py
+++ b/peda.py
@@ -6112,12 +6112,18 @@ peda.define_user_command("hook-stop",
     )
 
 # common used shell commands aliases
-shellcmds = ["man", "ls", "ps", "grep", "cat", "more", "less", "pkill", "vi", "nano"]
+shellcmds = [
+    "man", "ls", "ps", "grep", "cat", "rm",
+    "more", "less", "pkill", "vi", "vim", "nano",
+    "touch", "gcc", "nm", "objdump",
+]
 for cmd in shellcmds:
     Alias(cmd, "shell %s" % cmd)
 
 # shell commands that conflict with gdb commands
-_shellcmds = ["_clear", "_file"]
+_shellcmds = [
+    "_clear", "_file", "_ropgadget",
+]
 for cmd in _shellcmds:
     Alias(cmd, "shell %s" % cmd[1:])
 

--- a/peda.py
+++ b/peda.py
@@ -6115,7 +6115,8 @@ peda.define_user_command("hook-stop",
 shellcmds = [
     "man", "ls", "ps", "grep", "cat", "rm",
     "more", "less", "pkill", "vi", "vim", "nano",
-    "touch", "gcc", "nm", "objdump", "git"
+    "touch", "gcc", "nm", "objdump", "git",
+    "execstack", "ldd", "snoob"
 ]
 for cmd in shellcmds:
     Alias(cmd, "shell %s" % cmd)

--- a/peda.py
+++ b/peda.py
@@ -6114,10 +6114,10 @@ peda.define_user_command("hook-stop",
 # common used shell commands aliases
 shellcmds = ["man", "ls", "ps", "grep", "cat", "more", "less", "pkill", "vi", "nano"]
 for cmd in shellcmds:
-        Alias(cmd, "shell %s" % cmd)
+    Alias(cmd, "shell %s" % cmd)
 
-# common used shell commands aliases
-_shellcmds = ["_clear"]
+# shell commands that conflict with gdb commands
+_shellcmds = ["_clear", "_file"]
 for cmd in _shellcmds:
     Alias(cmd, "shell %s" % cmd[1:])
 

--- a/peda.py
+++ b/peda.py
@@ -6115,7 +6115,7 @@ peda.define_user_command("hook-stop",
 shellcmds = [
     "man", "ls", "ps", "grep", "cat", "rm",
     "more", "less", "pkill", "vi", "vim", "nano",
-    "touch", "gcc", "nm", "objdump",
+    "touch", "gcc", "nm", "objdump", "git"
 ]
 for cmd in shellcmds:
     Alias(cmd, "shell %s" % cmd)

--- a/peda.py
+++ b/peda.py
@@ -6112,9 +6112,14 @@ peda.define_user_command("hook-stop",
     )
 
 # common used shell commands aliases
-shellcmds = ["man", "ls", "ps", "grep", "cat", "more", "less", "pkill", "clear", "vi", "nano"]
+shellcmds = ["man", "ls", "ps", "grep", "cat", "more", "less", "pkill", "vi", "nano"]
 for cmd in shellcmds:
         Alias(cmd, "shell %s" % cmd)
+
+# common used shell commands aliases
+_shellcmds = ["_clear"]
+for cmd in _shellcmds:
+    Alias(cmd, "shell %s" % cmd[1:])
 
 # custom command aliases, add any alias you want
 Alias("phelp", "peda help")


### PR DESCRIPTION
Hi all,

I've mapped  `_clear` command to `shell clear` such that I can reuse GDB's native `clear` command and I've also added a `_file` command that aliases `shell file`.

I've also tested them, eg:

    gdb-peda$ _file *
    gdb-peda$ file my_executable
