### PR TITLE
configurable colors for addresses

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -37,6 +37,10 @@ OPTIONS = {
     "context"   : ("register,code,stack", "context display setting, e.g: register, code, stack, all"),
     "verbose"   : ("off", "show detail execution of commands, e.g: on|off"),
     "debug"     : ("off", "show detail error of peda commands, e.g: on|off"),
+    "color_addr_data"   : ("blue", "color of addresses to data"),
+    "color_addr_code"   : ("red", "color of addresses to code"),
+    "color_addr_rodata" : ("green", "color of addresses to rodata"),
+    "color_addr_value"  : ("none", "color of data"),
     "_teefd"    : ("", "internal use only for tracelog/crashlog writing")
 }
 
@@ -93,3 +97,11 @@ class Option(object):
             if name in opt and not opt.startswith("_"):
                 result[opt] = Option.options[opt][1]
         return result
+
+    @staticmethod
+    def get_default(name):
+        """get default value of option"""
+        if name in Option.options:
+            return Option.options[name][1]
+        else:
+            return None

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -438,16 +438,25 @@ def check_badchars(data, chars=None):
                 return True
     return False
 
-@memoized
+def get_color_for_type(type):
+    """Get the color to color an address of a given type"""
+    colorcode = config.Option.get("color_addr_%s" % type)
+    if colorcode not in ["black", "red", "green", "yellow", "blue", "purple", "cyan", "white", "none"]:
+        colorcode = config.Option.get_default("color_addr_%s" % type)
+    if colorcode == "none":
+        colorcode = None
+    return colorcode
+
 def format_address(addr, type):
     """Colorize an address"""
-    colorcodes = {
-        "data": "blue",
-        "code": "red",
-        "rodata": "green",
-        "value": None
-    }
-    return colorize(addr, colorcodes[type])
+    return format_address_color(addr, get_color_for_type(type))
+
+
+@memoized
+def format_address_color(addr, colorcode):
+    """Colorize an address"""
+    return colorize(addr, colorcode)
+
 
 @memoized
 def format_reference_chain(chain):

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -470,10 +470,7 @@ def format_reference_chain(chain):
     else:
         first = True
         for (v, t, vn) in chain:
-            if t != "value":
-                text += "%s%s " % ("--> " if not first else "", format_address(v, t))
-            else:
-                text += "%s%s " % ("--> " if not first else "", v)
+            text += "%s%s " % ("--> " if not first else "", format_address(v, t))
             first = False
 
         if vn:

--- a/peda.py
+++ b/peda.py
@@ -4404,7 +4404,10 @@ class PEDACmd(object):
         if "stack" in opt or "SIGSEGV" in status:
             self.context_stack(count)
         msg("[%s]" % ("-"*78), "blue")
-        msg("Legend: %s, %s, %s, value" % (red("code"), blue("data"), green("rodata")))
+        msg("Legend: %s, %s, %s, %s" % (colorize("code", get_color_for_type("code")),
+            colorize("data", get_color_for_type("data")),
+            colorize("rodata", get_color_for_type("rodata")),
+            colorize("value", get_color_for_type("value"))))
 
         # display stopped reason
         if "SIG" in status:


### PR DESCRIPTION
This is just a rebase (and moving to a branch like I should have done in the first place) of pull request #52 . I didn't even realize that pointers to rodata were colorized until I started looking at the peda source code due to my green terminal text. This change fixes that by allowing users to configure the colors used for pointers. As I said in the other PR:

I use a terminal with green text. This means that with peda, rodata (colored green) and value (no color) both look green and I miss out on context. I think a setup like this is common among people who use peda.

This change introduces the ability to specify colors for code, data, rodata, and values via settings. Defaults match the existing setup. Now, in my .gdbinit, after sourcing peda.py I have:

peda set option color_addr_value white

This commit only allows for the configuration of address colors. Other color coding is not yet configurable.
