### PR TITLE
fix context clearing implementation from 0321d83

### DIFF
--- a/peda.py
+++ b/peda.py
@@ -4270,7 +4270,7 @@ class PEDACmd(object):
 
         pc = peda.getreg("pc")
         # display register info
-        msg("\033[2J\033[0;0H [%s]" % "registers".center(78, "-"), "blue")
+        msg("[%s]" % "registers".center(78, "-"), "blue")
         self.xinfo("register")
 
         return
@@ -6113,6 +6113,7 @@ signal.signal(signal.SIGINT, sigint_handler)
 
 # custom hooks
 peda.define_user_command("hook-stop",
+    "clear\n"
     "peda context\n"
     "session autosave"
     )


### PR DESCRIPTION
The clearing with context from 0321d83 is a good idea, but its
implementation has a few issues:
1. The escape codes used prevent past frames from going into the
   terminal's scrollback history. That means you can't scroll back up as
   you stepped through the program to see how values in the context
   changed.
2. The clearing was done at the beginning of context_register. This had
   the side-effect of non-intuitively clearing the screen if you did an
   explicit "context reg" or if you did a "crashdump", hiding the parts of
   the crashdump printed before the register context.
3. Having some terminal escape sequences hiding in a message like that
   is bad form.

This change modifies the implementation to call clear in the stop hook
before calling context, fixing the above issues.
