### PR TITLE
Make context size and screen clearing configurable

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -37,6 +37,9 @@ OPTIONS = {
     "context"   : ("register,code,stack", "context display setting, e.g: register, code, stack, all"),
     "verbose"   : ("off", "show detail execution of commands, e.g: on|off"),
     "debug"     : ("off", "show detail error of peda commands, e.g: on|off"),
+    "code_size" : (8, "default number of lines to show for the code context"),
+    "stack_size": (8, "default number of lines to show for the stack context"),
+    "clearscr"  : (1, "clear screen after each step"),
     "_teefd"    : ("", "internal use only for tracelog/crashlog writing")
 }
 

--- a/peda.py
+++ b/peda.py
@@ -4270,7 +4270,7 @@ class PEDACmd(object):
 
         pc = peda.getreg("pc")
         # display register info
-        msg("\033[2J\033[0;0H [%s]" % "registers".center(78, "-"), "blue")
+        msg("[%s]" % "registers".center(78, "-"), "blue")
         self.xinfo("register")
 
         return
@@ -4285,7 +4285,11 @@ class PEDACmd(object):
         (count,) = normalize_argv(arg, 1)
 
         if count is None:
-            count = 8
+            size = config.Option.get("code_size")
+            try:
+                count = int(size)
+            except ValueError:
+                count = 8
 
         if not self._is_running():
             return
@@ -4354,6 +4358,13 @@ class PEDACmd(object):
         """
         (count,) = normalize_argv(arg, 1)
 
+        if count is None:
+            size = config.Option.get("stack_size")
+            try:
+                count = int(size)
+            except ValueError:
+                count = 8
+
         if not self._is_running():
             return
 
@@ -4376,8 +4387,6 @@ class PEDACmd(object):
 
         (opt, count) = normalize_argv(arg, 2)
 
-        if to_int(count) is None:
-            count = 8
         if opt is None:
             opt = config.Option.get("context")
         if opt == "all":
@@ -4390,6 +4399,10 @@ class PEDACmd(object):
 
         if not self._is_running():
             return
+
+        clearscr = config.Option.get("clearscr")
+        if clearscr:
+            msg("\033[2J\033[0;0H")
 
         status = peda.get_status()
         # display registers


### PR DESCRIPTION
* the number of lines of the context can be configured indepdentantly for the code and stack context
(this can be nice on high resolution screens)
* the screen clearing can be disabled using a config switch
(screen clearing can be disabled, allowing a scrollback buffer to compare to previous states)

=> let me know if I should make 2 patches out of this