### PR TITLE
context registers display in two columns

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -35,6 +35,7 @@ OPTIONS = {
     "autosave"  : ("on", "auto saving peda session, e.g: on|off"),
     "payload"   : ("peda-payload-#FILENAME#.txt", "target file to save output of payload command"),
     "context"   : ("register,code,stack", "context display setting, e.g: register, code, stack, all"),
+    "reg2cols"  : ("off", "context registers display in two columns"),
     "clearscr"  : ("on", "clear screen for each context display"),
     "verbose"   : ("off", "show detail execution of commands, e.g: on|off"),
     "debug"     : ("off", "show detail error of peda commands, e.g: on|off"),

--- a/lib/config.py
+++ b/lib/config.py
@@ -35,7 +35,7 @@ OPTIONS = {
     "autosave"  : ("on", "auto saving peda session, e.g: on|off"),
     "payload"   : ("peda-payload-#FILENAME#.txt", "target file to save output of payload command"),
     "context"   : ("register,code,stack", "context display setting, e.g: register, code, stack, all"),
-    "reg2cols"  : ("off", "context registers display in two columns"),
+    "maxlen"    : (80, "max length per line, over 120 then display registers in two columns"),
     "clearscr"  : ("on", "clear screen for each context display"),
     "verbose"   : ("off", "show detail execution of commands, e.g: on|off"),
     "debug"     : ("off", "show detail error of peda commands, e.g: on|off"),

--- a/peda.py
+++ b/peda.py
@@ -4271,7 +4271,7 @@ class PEDACmd(object):
 
         pc = peda.getreg("pc")
         # display register info
-        msg("[%s]" % "registers".center(158, "-"), "blue")
+        msg("[%s]" % "registers".center(158 if config.Option.get("reg2cols") == "on" else 78, "-"), "blue")
         self.xinfo("register")
 
         return
@@ -4297,7 +4297,7 @@ class PEDACmd(object):
         else:
             inst = None
 
-        text = blue("[%s]" % "code".center(158, "-"))
+        text = blue("[%s]" % "code".center(158 if config.Option.get("reg2cols") == "on" else 78, "-"))
         msg(text)
         if inst: # valid $PC
             text = ""
@@ -4358,7 +4358,7 @@ class PEDACmd(object):
         if not self._is_running():
             return
 
-        text = blue("[%s]" % "stack".center(158, "-"))
+        text = blue("[%s]" % "stack".center(158 if config.Option.get("reg2cols") == "on" else 78, "-"))
         msg(text)
         sp = peda.getreg("sp")
         if peda.is_address(sp):
@@ -4408,7 +4408,7 @@ class PEDACmd(object):
         # display stack content, forced in case SIGSEGV
         if "stack" in opt or "SIGSEGV" in status:
             self.context_stack(count)
-        msg("[%s]" % ("-"*158), "blue")
+        msg("[%s]" % ("-"*158 if config.Option.get("reg2cols") == "on" else 78), "blue")
         msg("Legend: %s, %s, %s, value" % (red("code"), blue("data"), green("rodata")))
 
         # display stopped reason

--- a/peda.py
+++ b/peda.py
@@ -4271,7 +4271,7 @@ class PEDACmd(object):
 
         pc = peda.getreg("pc")
         # display register info
-        msg("[%s]" % "registers".center(78, "-"), "blue")
+        msg("[%s]" % "registers".center(158, "-"), "blue")
         self.xinfo("register")
 
         return
@@ -4297,7 +4297,7 @@ class PEDACmd(object):
         else:
             inst = None
 
-        text = blue("[%s]" % "code".center(78, "-"))
+        text = blue("[%s]" % "code".center(158, "-"))
         msg(text)
         if inst: # valid $PC
             text = ""
@@ -4358,7 +4358,7 @@ class PEDACmd(object):
         if not self._is_running():
             return
 
-        text = blue("[%s]" % "stack".center(78, "-"))
+        text = blue("[%s]" % "stack".center(158, "-"))
         msg(text)
         sp = peda.getreg("sp")
         if peda.is_address(sp):
@@ -4408,7 +4408,7 @@ class PEDACmd(object):
         # display stack content, forced in case SIGSEGV
         if "stack" in opt or "SIGSEGV" in status:
             self.context_stack(count)
-        msg("[%s]" % ("-"*78), "blue")
+        msg("[%s]" % ("-"*158), "blue")
         msg("Legend: %s, %s, %s, value" % (red("code"), blue("data"), green("rodata")))
 
         # display stopped reason
@@ -4839,10 +4839,25 @@ class PEDACmd(object):
         if str(address).startswith("r"):
             # Register
             regs = peda.getregs(" ".join(arg[1:]))
+            reg_idx = 0
+            ansi_escape = re.compile(r'\x1b[^m]*m')
             if regname is None:
                 for r in REGISTERS[bits]:
                     if r in regs:
-                        text += get_reg_text(r, regs[r])
+                        if (reg_idx % 2 == 0):
+                            reg_text = get_reg_text(r, regs[r])[:-1].replace("\t", "    ")
+                            text += reg_text
+                            reg_text = ansi_escape.sub('', reg_text)
+                            reg_space = 80 - len(reg_text)
+                            if (reg_space > 0):
+                                text += " " * reg_space
+                                reg_idx += 1
+                            else:
+                                text += "\n"
+                                reg_idx += 2
+                        else:
+                            text += get_reg_text(r, regs[r])
+                            reg_idx += 1
             else:
                 for (r, v) in sorted(regs.items()):
                     text += get_reg_text(r, v)

--- a/peda.py
+++ b/peda.py
@@ -4844,7 +4844,7 @@ class PEDACmd(object):
             if regname is None:
                 for r in REGISTERS[bits]:
                     if r in regs:
-                        if (reg_idx % 2 == 0):
+                        if (config.Option.get("reg2cols") == "on" and reg_idx % 2 == 0):
                             reg_text = get_reg_text(r, regs[r])[:-1].replace("\t", "    ")
                             text += reg_text
                             reg_text = ansi_escape.sub('', reg_text)

--- a/peda.py
+++ b/peda.py
@@ -4408,7 +4408,7 @@ class PEDACmd(object):
         # display stack content, forced in case SIGSEGV
         if "stack" in opt or "SIGSEGV" in status:
             self.context_stack(count)
-        msg("[%s]" % ("-" * (config.Option.get("maxlen") - 2), "blue"))
+        msg("[%s]" % ("-" * (config.Option.get("maxlen") - 2)), "blue")
         msg("Legend: %s, %s, %s, value" % (red("code"), blue("data"), green("rodata")))
 
         # display stopped reason

--- a/peda.py
+++ b/peda.py
@@ -4271,7 +4271,7 @@ class PEDACmd(object):
 
         pc = peda.getreg("pc")
         # display register info
-        msg("[%s]" % "registers".center(158 if config.Option.get("reg2cols") == "on" else 78, "-"), "blue")
+        msg("[%s]" % "registers".center(config.Option.get("maxlen") - 2, "-"), "blue")
         self.xinfo("register")
 
         return
@@ -4297,7 +4297,7 @@ class PEDACmd(object):
         else:
             inst = None
 
-        text = blue("[%s]" % "code".center(158 if config.Option.get("reg2cols") == "on" else 78, "-"))
+        text = blue("[%s]" % "code".center(config.Option.get("maxlen") - 2, "-"))
         msg(text)
         if inst: # valid $PC
             text = ""
@@ -4358,7 +4358,7 @@ class PEDACmd(object):
         if not self._is_running():
             return
 
-        text = blue("[%s]" % "stack".center(158 if config.Option.get("reg2cols") == "on" else 78, "-"))
+        text = blue("[%s]" % "stack".center(config.Option.get("maxlen") - 2, "-"))
         msg(text)
         sp = peda.getreg("sp")
         if peda.is_address(sp):
@@ -4408,7 +4408,7 @@ class PEDACmd(object):
         # display stack content, forced in case SIGSEGV
         if "stack" in opt or "SIGSEGV" in status:
             self.context_stack(count)
-        msg("[%s]" % ("-"*158 if config.Option.get("reg2cols") == "on" else 78), "blue")
+        msg("[%s]" % ("-" * (config.Option.get("maxlen") - 2), "blue"))
         msg("Legend: %s, %s, %s, value" % (red("code"), blue("data"), green("rodata")))
 
         # display stopped reason
@@ -4840,15 +4840,16 @@ class PEDACmd(object):
             # Register
             regs = peda.getregs(" ".join(arg[1:]))
             reg_idx = 0
+            maxlen = config.Option.get("maxlen")
             ansi_escape = re.compile(r'\x1b[^m]*m')
             if regname is None:
                 for r in REGISTERS[bits]:
                     if r in regs:
-                        if (config.Option.get("reg2cols") == "on" and reg_idx % 2 == 0):
+                        if (maxlen >= 120 and reg_idx % 2 == 0):
                             reg_text = get_reg_text(r, regs[r])[:-1].replace("\t", "    ")
                             text += reg_text
                             reg_text = ansi_escape.sub('', reg_text)
-                            reg_space = 80 - len(reg_text)
+                            reg_space = int(maxlen / 2) - len(reg_text)
                             if (reg_space > 0):
                                 text += " " * reg_space
                                 reg_idx += 1


### PR DESCRIPTION
Context registers display in two columns is great for me. How about you?

Usage:
Set the option maxlen greater than 120 to enable.
`echo "peda set option maxlen 140" >> ~/.gdbinit`
Switch off:
`gdb-peda$ peda set option maxlen 80`
Switch on:
`gdb-peda$ peda set option maxlen 140`

![Ubuntu](https://user-images.githubusercontent.com/20320324/27318032-aa7590a4-55bc-11e7-9418-93f0a1914a1c.jpg)

![SecureCRT](https://cloud.githubusercontent.com/assets/20320324/25041522/30631c26-2143-11e7-9e5f-ff1f47a79101.png)
