### PR TITLE
fix skeleton stdin cannot use modified environment

### DIFF
--- a/lib/skeleton.py
+++ b/lib/skeleton.py
@@ -150,7 +150,7 @@ def exploit(vuln):
     args = sys.argv[1:]
     resource.setrlimit(resource.RLIMIT_STACK, (-1, -1))
     resource.setrlimit(resource.RLIMIT_CORE, (-1, -1))
-    P = Popen(args, stdin=PIPE)
+    P = Popen(args, stdin=PIPE, env=env)
     P.stdin.write(payload + "\\n")
     while True:
         line = sys.stdin.readline()


### PR DESCRIPTION
`Popen` missing `env` argument