### PR TITLE
Fix a bug in the string_to_argv method

### DIFF
--- a/peda.py
+++ b/peda.py
@@ -195,8 +195,7 @@ class PEDA(object):
             str = str.encode('ascii', 'ignore')
         except:
             pass
-        str = decode_string_escape(str)
-        args = shlex.split(str)
+        args = list(map(lambda x: decode_string_escape(x), shlex.split(str.decode())))
         # need more processing here
         for idx, a in enumerate(args):
             a = a.strip(",")


### PR DESCRIPTION
Fixed a bug where the lexer fails to parse some commands containing escaped quotes.

gdb commands to reproduce the bug:
patch $rsp "ab\x22cd"
patch $rsp 'ab\x22\x27cd'
Should write 5 bytes to the memory at address in $rsp, but it fails, shlex gets (patch $rsp "ab"cd"), and fails to parse that expression (invalid quotes).
