### PR TITLE
Added display commands of breakpoint when breakpoint hit

### DIFF
--- a/peda.py
+++ b/peda.py
@@ -4414,6 +4414,14 @@ class PEDACmd(object):
         if "SIG" in status:
             msg("Stopped reason: %s" % red(status))
 
+        # display breakpoint commands
+        bplist = peda.get_breakpoints()
+        for bp in bplist:
+            addr, cmds = bp[4], bp[6]
+            if addr == peda.getreg("pc") and cmds != "":
+                for _ in bp[6].split('\n'): peda.execute(_) 
+                break
+           
         return
 
     def breakrva(self, *arg):


### PR DESCRIPTION
If breakpoint command lines exist, results of command printed before `context` and disappeared.
So I should scroll up to check the result.


![image](https://user-images.githubusercontent.com/3019914/51093945-d0d6c400-17eb-11e9-9e40-772e4ac1325a.png)
