### PR TITLE
Fixed peda.getpid() when debugging remote processes

### DIFF
--- a/peda.py
+++ b/peda.py
@@ -421,26 +421,6 @@ class PEDA(object):
         status = self.get_status()
         if not status or status == "STOPPED":
             return None
-
-        if self.is_target_remote(): # remote target
-            ctx = config.Option.get("context")
-            config.Option.set("context", None)
-            try:
-                out = self.execute_redirect("call getpid()")
-            except:
-                pass
-
-            config.Option.set("context", ctx)
-
-            if out is None:
-                return None
-            else:
-                out = self.execute_redirect("print $")
-                if out:
-                    return to_int(out.split("=")[1])
-                else:
-                    return None
-
         pid = gdb.selected_inferior().pid
         return int(pid) if pid else None
 
@@ -3060,7 +3040,7 @@ class PEDACmd(object):
         """
         pid = peda.getpid()
         if pid is None:
-            text = "not running or target is remote"
+            text = "not running"
             warning_msg(text)
             return None
             #raise Exception(text)


### PR DESCRIPTION
**Bug:**
_peda.getpid()_ returns None for remote processes

**Why it doesn't work:**
if the target is remote, it attempts to _call getpid()_, which might not work in all cases (It's not casting the return type, libc might not be loaded on some executables etc.)

**Consequences:**
__is_running()_ checks if the pid is not None, commands like telescope, context (and many others) don't work correctly, and just warn "not running or target is remote", because they check if __is_running()_.

**Fix:**
Looks like we can get the pid from the inferior, in a way that works for both local and remote processes.

**Todo:**
Ensure that all the functions calling __is_running()_ work fine with remote processes.