### PR TITLE
Added ability to change where peda files are saved

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -27,6 +27,7 @@ OPTIONS = {
     "indent"    : (4, "number of ident spaces for output python payload, e.g: 0|4|8"),
     "ansicolor" : ("on", "enable/disable colorized output, e.g: on|off"),    
     "pagesize"  : (25, "number of lines to display per page, 0 = disable paging"),
+    "savedir"   : ("~/.peda_files/", "where to save generated files (e.g: peda-session-#FILENAME#.txt), empty to save to cwd"),
     "session"   : ("peda-session-#FILENAME#.txt", "target file to save peda session"),
     "tracedepth": (0, "max depth for calls/instructions tracing, 0 means no limit"),
     "tracelog"  : ("peda-trace-#FILENAME#.txt", "target file to save tracecall output"),

--- a/peda.py
+++ b/peda.py
@@ -655,8 +655,21 @@ class PEDA(object):
         except:
             return False
 
+
+    def get_save_directory_location(self):
+        directory = config.Option.get('savedir')
+        home = os.path.expanduser('~')
+        directory = directory.replace('~', home)    # Ensure ~ references home not folder '~'
+        if directory != '':
+            if not os.path.exists(directory):   # Make sure directory exists
+                os.makedirs(directory)
+            return directory
+        else:
+            return ''
+
     def get_config_filename(self, name):
         filename = peda.getfile()
+        save_dir = self.get_save_directory_location()
         if not filename:
             filename = peda.getpid()
             if not filename:
@@ -665,9 +678,9 @@ class PEDA(object):
         filename = os.path.basename("%s" % filename)
         tmpl_name = config.Option.get(name)
         if tmpl_name:
-            return tmpl_name.replace("#FILENAME#", filename)
+            return save_dir + tmpl_name.replace("#FILENAME#", filename)   # Append directory to filename
         else:
-            return "peda-%s-%s" % (name, filename)
+            return save_dir + "peda-%s-%s" % (name, filename)
 
     def save_session(self, filename=None):
         """


### PR DESCRIPTION
Currently files such as peda-session-###.txt are saved in cwd (current working directory). I made some changes that allow all such files to be saved to a common folder for all projects or a relative folder to cwd. Saving works without a problem but didn't do any extensive bug checking and I have not tested restoring sessions.