### PR TITLE
fix: SyntaxWarning: "is" with a literal. Did you mean "=="?

### DIFF
--- a/peda.py
+++ b/peda.py
@@ -42,7 +42,7 @@ from utils import *
 import config
 from nasm import *
 
-if sys.version_info.major is 3:
+if sys.version_info.major == 3:
     from urllib.request import urlopen
     from urllib.parse import urlencode
     pyversion = 3
@@ -5789,9 +5789,9 @@ class PEDACmd(object):
                 while True:
                     for os in oslist:
                         msg('%s %s'%(yellow('[+]'),green(os)))
-                    if pyversion is 2:
+                    if pyversion == 2:
                         os = input('%s'%blue('os:'))
-                    if pyversion is 3:
+                    if pyversion == 3:
                         os = input('%s'%blue('os:'))
                     if os in oslist: #check if os exist
                         break
@@ -5800,9 +5800,9 @@ class PEDACmd(object):
                 while True:
                     for job in joblist:
                         msg('%s %s'%(yellow('[+]'),green(job)))
-                    if pyversion is 2:
+                    if pyversion == 2:
                         job = raw_input('%s'%blue('job:'))
-                    if pyversion is 3:
+                    if pyversion == 3:
                         job = input('%s'%blue('job:'))
                     if job != '':
                         break
@@ -5811,9 +5811,9 @@ class PEDACmd(object):
                 while True:
                     for encode in encodelist:
                         msg('%s %s'%(yellow('[+]'),green(encode)))
-                    if pyversion is 2:
+                    if pyversion == 2:
                         encode = raw_input('%s'%blue('encode:'))
-                    if pyversion is 3:
+                    if pyversion == 3:
                         encode = input('%s'%blue('encode:'))
                     if encode != '':
                         break


### PR DESCRIPTION
With python 3.8.0:

```
/usr/share/peda/peda.py:45: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if sys.version_info.major is 3:
/usr/share/peda/peda.py:5780: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if pyversion is 2:
/usr/share/peda/peda.py:5782: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if pyversion is 3:
/usr/share/peda/peda.py:5791: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if pyversion is 2:
/usr/share/peda/peda.py:5793: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if pyversion is 3:
/usr/share/peda/peda.py:5802: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if pyversion is 2:
/usr/share/peda/peda.py:5804: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if pyversion is 3:
```

The PR should fix it