### PR TITLE
Use `==` instead of `is` when comparing with literal

### DIFF
--- a/lib/shellcode.py
+++ b/lib/shellcode.py
@@ -21,7 +21,7 @@ import sys
 import config
 from utils import msg, error_msg
 
-if sys.version_info.major is 3:
+if sys.version_info.major == 3:
     from urllib.request import urlopen
     from urllib.parse import urlencode
     pyversion = 3
@@ -376,7 +376,7 @@ class Shellcode():
                     'job': job,
                     'encode': encode})
             shellcode = urlopen("http://api.z3r0d4y.com/index.py?%s\n"%(str(params))).read()
-            if pyversion is 3:
+            if pyversion == 3:
                 shellcode = str(shellcode,encoding='ascii')
             return '\n"'+shellcode.replace('\n','')+'"\n'
         except:


### PR DESCRIPTION
`gdb` spits `SyntaxWarning: "is" with a literal. Did you mean "=="?` on startup.

Generally `==` should be used unless we are trying to check if both sides are the same object.

`x is 3` works because Python stores small integers at a fixed address. 
It won't work as intended if the literal is large. For example:
```
> x = 300
> x is 300
False
```