### PR TITLE
Fixed syntax warning in libs/shellcode.py

### DIFF
--- a/lib/shellcode.py
+++ b/lib/shellcode.py
@@ -21,7 +21,7 @@ import sys
 import config
 from utils import msg, error_msg
 
-if sys.version_info.major is 3:
+if sys.version_info.major == 3:
     from urllib.request import urlopen
     from urllib.parse import urlencode
     pyversion = 3
@@ -376,7 +376,7 @@ class Shellcode():
                     'job': job,
                     'encode': encode})
             shellcode = urlopen("http://api.z3r0d4y.com/index.py?%s\n"%(str(params))).read()
-            if pyversion is 3:
+            if pyversion == 3:
                 shellcode = str(shellcode,encoding='ascii')
             return '\n"'+shellcode.replace('\n','')+'"\n'
         except:


### PR DESCRIPTION
Fixes issues #153 and #147 

integer comparisons were being done using 'is' which threw syntax warnings in gdb. This has been fixed by using the right comparison operator that is the '==' operator.

