### PR TITLE
docs: fix simple typo, sequece -> sequence

### DIFF
--- a/python23-compatibility.md
+++ b/python23-compatibility.md
@@ -34,7 +34,7 @@ isinstance(x, six.integer_types)
 ## Strings
 
 In Python 2, `bytes` is an alias for `str`. In Python 3, `str` is a unicode
-type and `bytes` is used for a sequece of arbitrary bytes. Use a leading 'b' to
+type and `bytes` is used for a sequence of arbitrary bytes. Use a leading 'b' to
 signify that a string is a `bytes` object.
 
 ```python


### PR DESCRIPTION
There is a small typo in python23-compatibility.md.

Should read `sequence` rather than `sequece`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md