### PR TITLE
Fix bug that makes peda not show register, code, stack information

### DIFF
--- a/peda.py
+++ b/peda.py
@@ -4299,7 +4299,7 @@ class PEDACmd(object):
                         if idx <= pc_idx:
                             text += line + "\n"
                         else:
-                            text += " | %s\n" % line.strip()
+                            text += " | %s\n" % line
                     text = format_disasm_code(text, pc) + "\n"
                     text += " |->"
                     code = peda.get_disasm(jumpto, count//2)


### PR DESCRIPTION
peda uses gdb command x/i to get assembly code. In small sized termial,
gdb may return something like this

	0x4003f0:\t\njmp    QWORD PTR [rip+0x200c22]        # 0x601018\n

In context_code function, the above result will become 2 lines, if the
first line reach the else case in this if:

	if idx <= pc_idx:
		text += line + "\n"
	else:
		text += " | %s\n" % line.strip()

and it will become

	0x4003f0: (without the tab)

When this line is processed by format_disasm_code function

	prefix = line.split(":\t")[0]
	addr = re.search("(0x[^\s]*)", prefix)
	if addr:
		addr = to_int(addr.group(1))

to_int is called with "0x4003f0:" argument and it will return None which
will raise an exception in later comparison.

context_code function has msg.bufferize decorator so the exception prevents
msg.flush to be called, the msg.buffering will not be decreased. As a result,
no information can be displayed later since we get the output only when
msg.buffering equals to 0.