### PR TITLE
Changed shellstorm url format

### DIFF
--- a/lib/shellcode.py
+++ b/lib/shellcode.py
@@ -354,7 +354,7 @@ class Shellcode():
             return None
 
         try:
-            s.request("GET", "/shellcode/files/shellcode-"+str(shellcodeId)+".php")
+            s.request("GET", "/shellcode/files/shellcode-"+str(shellcodeId)+".html")
             res = s.getresponse()
             data = res.read().decode('utf-8').split("<pre>")[1].split("<body>")[0]
         except:


### PR DESCRIPTION
When using `shellcode display` peda returns the error `Error: Failed to download shellcode from shell-storm.org`.

This is caused by the fact that it requests the url with .php suffix whereas the shellcode are in .html files.