### PR TITLE
remove deprecated notice

### DIFF
--- a/peda.py
+++ b/peda.py
@@ -108,22 +108,22 @@ class PEDA(object):
         else:
             logfd = tmpfile()
         logname = logfd.name
-        gdb.execute('set logging off') # prevent nested call
+        gdb.execute('set logging enabled off') # prevent nested call
         gdb.execute('set height 0') # disable paging
         gdb.execute('set logging file %s' % logname)
         gdb.execute('set logging overwrite on')
         gdb.execute('set logging redirect on')
-        gdb.execute('set logging on')
+        gdb.execute('set logging enabled on')
         try:
             gdb.execute(gdb_command)
             gdb.flush()
-            gdb.execute('set logging off')
+            gdb.execute('set logging enabled off')
             if not silent:
                 logfd.flush()
                 result = logfd.read()
             logfd.close()
         except Exception as e:
-            gdb.execute('set logging off') #to be sure
+            gdb.execute('set logging enabled off') #to be sure
             if config.Option.get("debug") == "on":
                 msg('Exception (%s): %s' % (gdb_command, e), "red")
                 traceback.print_exc()
@@ -6112,7 +6112,7 @@ for cmd in pedacmd.commands:
 # handle SIGINT / Ctrl-C
 def sigint_handler(signal, frame):
     warning_msg("Got Ctrl+C / SIGINT!")
-    gdb.execute("set logging off")
+    gdb.execute("set logging enabled off")
     peda.restore_user_command("all")
     raise KeyboardInterrupt
 signal.signal(signal.SIGINT, sigint_handler)


### PR DESCRIPTION
From GDB 12.1+, `set logging on|off` is deprecated, and a notice is given. See
<https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=blob_plain;f=gdb/NEWS;hb=gdb-12.1-release>. This patch fixes the issue for the newer gdb versions.